### PR TITLE
[tool] 코드 및 바이너리를 추출할 때 파일 헤더의 정보를 변경할 수 있는 옵션 추가

### DIFF
--- a/tools/Ntreev.Crema.Commands/GetCodeCommand.cs
+++ b/tools/Ntreev.Crema.Commands/GetCodeCommand.cs
@@ -27,6 +27,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Ntreev.Crema.Commands.OptionProcessor;
 
 namespace Ntreev.Crema.Commands
 {
@@ -34,6 +35,7 @@ namespace Ntreev.Crema.Commands
     [CommandStaticProperty(typeof(CodeSettings))]
     [CommandStaticProperty(typeof(FilterSettings))]
     [CommandStaticProperty(typeof(DataBaseSettings))]
+    [CommandStaticProperty(typeof(ReplaceSettings))]
     class GetCodeCommand : CommandBase
     {
         [Import]
@@ -106,6 +108,7 @@ namespace Ntreev.Crema.Commands
 
             this.Out.WriteLine("receiving info");
             var metaData = this.service.GetMetaData(this.Address, DataBaseSettings.DataBaseName, DataBaseSettings.Tags, FilterSettings.FilterExpression, CodeSettings.Devmode, this.Revision);
+            metaData = ReplaceOptionProcessor.Process(metaData);
 
             var generationSettings = new CodeGenerationSettings()
             {

--- a/tools/Ntreev.Crema.Commands/GetCommand.cs
+++ b/tools/Ntreev.Crema.Commands/GetCommand.cs
@@ -29,6 +29,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Ntreev.Crema.Commands.OptionProcessor;
 
 namespace Ntreev.Crema.Commands
 {
@@ -36,6 +37,7 @@ namespace Ntreev.Crema.Commands
     [CommandStaticProperty(typeof(CodeSettings))]
     [CommandStaticProperty(typeof(FilterSettings))]
     [CommandStaticProperty(typeof(DataBaseSettings))]
+    [CommandStaticProperty(typeof(ReplaceSettings))]
     class GetCommand : CommandBase
     {
         [Import]
@@ -114,6 +116,7 @@ namespace Ntreev.Crema.Commands
 
             this.Out.WriteLine("receiving info");
             var metaData = this.service.GetMetaData(this.Address, DataBaseSettings.DataBaseName, DataBaseSettings.Tags, FilterSettings.FilterExpression, CodeSettings.Devmode, this.Revision);
+            metaData = ReplaceOptionProcessor.Process(metaData);
 
             var generationSettings = new CodeGenerationSettings()
             {

--- a/tools/Ntreev.Crema.Commands/GetDataCommand.cs
+++ b/tools/Ntreev.Crema.Commands/GetDataCommand.cs
@@ -28,6 +28,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Ntreev.Crema.Commands.OptionProcessor;
 
 namespace Ntreev.Crema.Commands
 {
@@ -35,6 +36,7 @@ namespace Ntreev.Crema.Commands
     [CommandStaticProperty(typeof(FilterSettings))]
     [CommandStaticProperty(typeof(DataBaseSettings))]
     [CommandStaticProperty(typeof(DataSplitSetting))]
+    [CommandStaticProperty(typeof(ReplaceSettings))]
     class GetDataCommand : CommandBase
     {
         [Import]
@@ -104,6 +106,7 @@ namespace Ntreev.Crema.Commands
 
             this.Out.WriteLine("receiving info");
             var metaData = service.GetDataGenerationData(this.Address, DataBaseSettings.DataBaseName, DataBaseSettings.Tags, FilterSettings.FilterExpression, this.Devmode, this.Revision);
+            metaData = ReplaceOptionProcessor.Process(metaData);
 
             this.Out.WriteLine("data serializing.");
             var serializer = this.serializers.FirstOrDefault(item => item.Name == this.OutputType);
@@ -135,6 +138,8 @@ namespace Ntreev.Crema.Commands
             foreach (var table in metaData.Tables)
             {
                 var filteredMetaData = metaData.Filter(table.Name);
+                filteredMetaData = ReplaceOptionProcessor.Process(filteredMetaData);
+
                 if (filteredMetaData.Tables.Any())
                 {
                     metaDataList.Add(filteredMetaData);

--- a/tools/Ntreev.Crema.Commands/Ntreev.Crema.Commands.csproj
+++ b/tools/Ntreev.Crema.Commands/Ntreev.Crema.Commands.csproj
@@ -45,6 +45,8 @@
   <ItemGroup>
     <Compile Include="CodeSettings.cs" />
     <Compile Include="DataBaseSettings.cs" />
+    <Compile Include="OptionProcessor\ReplaceOptionProcessor.cs" />
+    <Compile Include="ReplaceSettings.cs" />
     <Compile Include="DataSplitSetting.cs" />
     <Compile Include="FilterSettings.cs" />
     <Compile Include="GetCodeCommand.cs" />

--- a/tools/Ntreev.Crema.Commands/OptionProcessor/ReplaceOptionProcessor.cs
+++ b/tools/Ntreev.Crema.Commands/OptionProcessor/ReplaceOptionProcessor.cs
@@ -1,0 +1,65 @@
+﻿//Released under the MIT License.
+//
+//Copyright (c) 2018 Ntreev Soft co., Ltd.
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+//documentation files (the "Software"), to deal in the Software without restriction, including without limitation the 
+//rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit 
+//persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all copies or substantial portions of the 
+//Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+//WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+//COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR 
+//OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Ntreev.Crema.Runtime.Generation;
+using Ntreev.Crema.Runtime.Serialization;
+
+namespace Ntreev.Crema.Commands.OptionProcessor
+{
+    static class ReplaceOptionProcessor
+    {
+        public static Tuple<GenerationSet, SerializationSet> Process(Tuple<GenerationSet, SerializationSet> metaData)
+        {
+            var generationSet = metaData.Item1;
+            var serializationSet = metaData.Item2;
+
+            generationSet = Process(generationSet);
+            serializationSet = Process(serializationSet);
+
+            return new Tuple<GenerationSet, SerializationSet>(generationSet, serializationSet);
+        }
+
+        public static GenerationSet Process(GenerationSet generationSet)
+        {
+            if (ReplaceSettings.ReplaceHashValue != null)
+            {
+                generationSet.Revision = ReplaceSettings.ReplaceRevision;
+                generationSet.TablesHashValue = ReplaceSettings.ReplaceHashValue;
+                generationSet.TypesHashValue = ReplaceSettings.ReplaceHashValue;
+            }
+
+            return generationSet;
+        }
+
+        public static SerializationSet Process(SerializationSet serializationSet)
+        {
+            if (ReplaceSettings.ReplaceRevision != long.MinValue)
+            {
+                serializationSet.Revision = ReplaceSettings.ReplaceRevision;
+                serializationSet.TablesHashValue = ReplaceSettings.ReplaceHashValue;
+                serializationSet.TypesHashValue = ReplaceSettings.ReplaceHashValue;
+            }
+
+            return serializationSet;
+        }
+    }
+}

--- a/tools/Ntreev.Crema.Commands/ReplaceSettings.cs
+++ b/tools/Ntreev.Crema.Commands/ReplaceSettings.cs
@@ -25,25 +25,22 @@ using Ntreev.Library.Commands;
 
 namespace Ntreev.Crema.Commands
 {
-    static class DataSplitSetting
+    static class ReplaceSettings
     {
-        private static string ext;
-
         [CommandProperty]
-        [Description("크레마의 테이블 이름별로 데이터 파일을 출력합니다.\n이 옵션을 사용하면 필수인자 <filename> 은 출력할 디렉토리로 사용합니다.")]
-        [DefaultValue(false)]
-        public static bool Split
+        [DefaultValue((long)long.MinValue)]
+        [Description("바이너리 파일 헤더의 Revision 값을 변경합니다.")]
+        public static long ReplaceRevision
         {
             get; set;
         }
 
-        [CommandProperty]
-        [Description("--split 옵션을 사용할 경우 이 옵션으로 출력 파일의 확장자를 지정합니다.")]
-        [DefaultValue("dat")]
-        public static string Ext
+        [CommandProperty("replace-hashvalue")]
+        [DefaultValue(null)]
+        [Description("바이너리 파일 헤더의 TablesHashValue, TypesHashValue 값을 변경합니다.")]
+        public static string ReplaceHashValue
         {
-            get => ext;
-            set => ext = value.StartsWith(".") ? value.Remove(0, 1) : value;
+            get; set;
         }
     }
 }


### PR DESCRIPTION
코드 또는 바이너리를 추출할 때 코드에 바이너리 정보 또는 파일 헤더의 정보를 변경할 수 있다.
- 추출된 코드의 리버전 정보, 해시값을 변경
- 추출된 바이너리의 파일 헤더의 리비전, 해시값을 변경

사용예) .\cremadev.exe get [address] [path] --database Default --replace-revision 0 --replace-hashvalue 0