### PR TITLE
[tool] cremadev get-data split 옵션 버그 수정

### DIFF
--- a/common/Ntreev.Crema.Runtime.Serialization/Binary/BinaryDataSerializer.cs
+++ b/common/Ntreev.Crema.Runtime.Serialization/Binary/BinaryDataSerializer.cs
@@ -37,6 +37,7 @@ using System.Threading.Tasks;
 namespace Ntreev.Crema.Runtime.Serialization.Binary
 {
     [Export(typeof(IDataSerializer))]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
     class BinaryDataSerializer : IDataSerializer
     {
         public const int formatterVersion = 0;

--- a/tools/Ntreev.Crema.ConsoleHost/Container.cs
+++ b/tools/Ntreev.Crema.ConsoleHost/Container.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using System.Text;
@@ -31,6 +32,7 @@ namespace Ntreev.Crema.ConsoleHost
         static Container()
         {
             container = new CompositionContainer(new DirectoryCatalog(AppDomain.CurrentDomain.BaseDirectory));
+            container.ComposeExportedValue(container);
         }
 
         public static T Get<T>()


### PR DESCRIPTION
get-data filter 와 split 옵션 사용 시 버그가 발생한다.
MEF 개체 Container 에서 BinaryDataSerializer 의 싱글톤 인스턴스를 반환하여,
BinaryDataSerializer 의 인스턴스 맴버가 초기화가 되지 않아 발생하는 문제

BinaryDataSerializer 의 객체 수명 규칙을 CreationPolicy.NonShared 로 변경함